### PR TITLE
Update Dockerfile to specify UID & GID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20-alpine
 LABEL org.opencontainers.image.source=https://github.com/thristhart/kitchensync-2024
 
-RUN addgroup -S app && adduser -S app -G app
+RUN addgroup -S app --gid=1234 && adduser -S app -G app --uid 1234
 
 COPY . /srv/kitchensync
 WORKDIR /srv/kitchensync


### PR DESCRIPTION
Paired with a `chown -R 1234:1234 /path/to/kitchensync/db-folder`